### PR TITLE
Fix streaming of partial JSON documents

### DIFF
--- a/lib/jaxon/parse_error.ex
+++ b/lib/jaxon/parse_error.ex
@@ -48,6 +48,10 @@ defmodule Jaxon.ParseError do
     msg
   end
 
+  def message(%{unexpected: unexpected, expected: []}) do
+    "Unexpected #{event_to_pretty_name(unexpected)}"
+  end
+
   def message(%{unexpected: unexpected, expected: expected}) do
     expected =
       expected

--- a/test/stream_test.exs
+++ b/test/stream_test.exs
@@ -83,4 +83,13 @@ defmodule JaxonEventStreamTest do
 
     assert Enum.take(Elixir.Stream.cycle([%{"key" => true}]), 30) == result
   end
+
+  test "it doesn't error when incomplete JSON is streamed" do
+    result =
+      [~s([{"numbers":[1,2],"key":"hello")]
+      |> Stream.query([:root, :all, "key"])
+      |> Enum.to_list()
+
+    assert result == ["hello"]
+  end
 end

--- a/test/stream_test.exs
+++ b/test/stream_test.exs
@@ -64,6 +64,15 @@ defmodule JaxonEventStreamTest do
     assert Enum.take(Elixir.Stream.cycle([1, 2]), 30) == result
   end
 
+  test "multiple JSON doucuments in a stream chunk" do
+    result =
+      ["#{@json_stream}\n#{@json_stream}"]
+      |> Stream.query([:root, "numbers", :all])
+      |> Enum.to_list()
+
+    assert [1, 2, 1, 2] == result
+  end
+
   test "single values" do
     result =
       ["42\n"]


### PR DESCRIPTION
This fixes a few issues:

- When a partial document is sent, don't error and expect more events
- When a JSON document ends, keep parsing in case there is another