### PR TITLE
Fix number parsing when buffer ends at decimal dot

### DIFF
--- a/c_src/decoder.c
+++ b/c_src/decoder.c
@@ -75,10 +75,16 @@ void parse_number(decoder_t* d, json_event_t* e) {
         buf++;
     }
 
-    if(*buf == '.' || !is_digit(*(buf - 1))) {
+    if(buf < limit && *(buf - 1) == '.' && !is_digit(*buf)) {
         syntax_error(d, e);
         return;
     }
+
+    if(*(buf - 1) == '.' && (buf - 1) == decimal_point) {
+        buf--;
+        goto done;
+    }
+
 
     if(decimal_point) {
         frac_exp = -(buf - decimal_point - 1);
@@ -127,7 +133,7 @@ done:
         *buf == '-' || *buf == '+')) {
         e->type = INCOMPLETE;
         e->value.string.buffer = d->last_token;
-        e->value.string.size = buf - d->last_token;
+        e->value.string.size = (buf+1) - d->last_token;
     } else {
         long int abs_exp = labs(exp + frac_exp);
 

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -54,10 +54,30 @@ defmodule ParseTest do
      [
        :end_object,
        :end_object
+     ]},
+    {~s(5e ),
+     [
+       {:error, "5e "}
+     ]},
+    {~s(5e),
+     [
+       {:incomplete, "5e"}
+     ]},
+    {~s(5..),
+     [
+       {:error, "5.."}
+     ]},
+    {~s(5. ),
+     [
+       {:error, "5. "}
+     ]},
+    {~s(5.),
+     [
+       {:incomplete, "5."}
      ]}
   ]
 
-  test "decoder tests" do
+  test "parser tests" do
     Enum.each(@tests, fn {json, events} ->
       assert Parser.parse(json) == events
     end)


### PR DESCRIPTION
Before:

```
Parser.parse(~s(5.)) == {:error, "5."}
```

This prevents the streamer to work properly when a chunk ends exactly at the decimal separator.

Now:

```
Parser.parse(~s(5.)) == {:incomplete, "5."}
```