### PR TITLE
Fix escaped unicode parsing when sequence is incomplete

### DIFF
--- a/c_src/decoder.c
+++ b/c_src/decoder.c
@@ -338,8 +338,9 @@ uint8_t* parse_string(uint8_t* buffer, uint8_t* limit, size_t* escapes) {
 
                                 continue;
                             } else {
-                                return buf;
+                                return limit;
                             }
+
                             break;
 
                         default:

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -74,7 +74,11 @@ defmodule ParseTest do
     {~s(5.),
      [
        {:incomplete, "5."}
-     ]}
+     ]},
+     {~s("\\u00),
+     [
+       {:incomplete, ~s("\\u00)}
+     ]},
   ]
 
   test "parser tests" do


### PR DESCRIPTION
Before:

```
Parser.parse(~s("\\u00)) == {:error, ~s("\\u00)}
```

This prevents the streamer to work properly when a chunk ends in the middle of an incomplete unicode sequence.

Now:

```
Parser.parse(~s("\\u00)) == {:incomplete, ~s("\\u00)}
```