### PR TITLE
Performance Fixes

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -16,131 +16,131 @@ Estimated total run time: 4.67 min
 
 ##### With input Blockchain #####
 Name             ips        average  deviation         median         99th %
-jiffy         3.12 K      320.20 μs    ±25.14%         302 μs      607.53 μs
-Jaxon         2.76 K      362.34 μs    ±24.76%         351 μs      683.16 μs
-Jason         2.32 K      430.65 μs    ±19.67%         404 μs      793.99 μs
-Poison        1.11 K      904.20 μs    ±18.07%         875 μs        1608 μs
+Jaxon         3.29 K      303.66 μs    ±21.44%         297 μs      465.08 μs
+jiffy         3.23 K      309.55 μs    ±21.07%         298 μs         493 μs
+Jason         2.47 K      404.95 μs    ±11.30%         399 μs         547 μs
+Poison        1.20 K      836.91 μs    ±10.18%         836 μs        1050 μs
 
 Comparison:
-jiffy         3.12 K
-Jaxon         2.76 K - 1.13x slower
-Jason         2.32 K - 1.34x slower
-Poison        1.11 K - 2.82x slower
+Jaxon         3.29 K
+jiffy         3.23 K - 1.02x slower
+Jason         2.47 K - 1.33x slower
+Poison        1.20 K - 2.76x slower
 
 ##### With input Giphy #####
 Name             ips        average  deviation         median         99th %
-jiffy         398.44        2.51 ms    ±11.85%        2.48 ms        3.01 ms
-Jaxon         286.09        3.50 ms    ±15.27%        3.48 ms        4.87 ms
-Jason         225.95        4.43 ms    ±12.23%        4.30 ms        6.42 ms
-Poison         88.67       11.28 ms     ±8.83%       10.81 ms       13.98 ms
+jiffy         393.99        2.54 ms     ±3.84%        2.53 ms        2.73 ms
+Jaxon         347.24        2.88 ms    ±17.58%        2.52 ms        4.20 ms
+Jason         241.14        4.15 ms     ±5.19%        4.17 ms        4.68 ms
+Poison        105.56        9.47 ms     ±2.61%        9.43 ms       10.14 ms
 
 Comparison:
-jiffy         398.44
-Jaxon         286.09 - 1.39x slower
-Jason         225.95 - 1.76x slower
-Poison         88.67 - 4.49x slower
+jiffy         393.99
+Jaxon         347.24 - 1.13x slower
+Jason         241.14 - 1.63x slower
+Poison        105.56 - 3.73x slower
 
 ##### With input GitHub #####
 Name             ips        average  deviation         median         99th %
-Jaxon         1.21 K        0.83 ms    ±20.43%        0.75 ms        1.46 ms
-jiffy         1.17 K        0.85 ms    ±17.99%        0.88 ms        1.18 ms
-Jason         0.80 K        1.25 ms    ±15.02%        1.18 ms        2.05 ms
-Poison        0.38 K        2.66 ms    ±14.85%        2.51 ms        4.18 ms
+Jaxon         1.38 K        0.73 ms    ±12.17%        0.69 ms        1.05 ms
+jiffy         1.17 K        0.86 ms    ±17.65%        0.87 ms        1.19 ms
+Jason         0.86 K        1.16 ms    ±13.89%        1.14 ms        1.37 ms
+Poison        0.40 K        2.50 ms     ±6.22%        2.49 ms        3.02 ms
 
 Comparison:
-Jaxon         1.21 K
-jiffy         1.17 K - 1.03x slower
-Jason         0.80 K - 1.51x slower
-Poison        0.38 K - 3.22x slower
+Jaxon         1.38 K
+jiffy         1.17 K - 1.18x slower
+Jason         0.86 K - 1.59x slower
+Poison        0.40 K - 3.44x slower
 
 ##### With input GovTrack #####
 Name             ips        average  deviation         median         99th %
-jiffy           9.90      101.01 ms     ±2.63%      100.82 ms      106.37 ms
-Jason           7.90      126.60 ms     ±4.01%      127.05 ms      134.57 ms
-Jaxon           5.25      190.35 ms     ±2.88%      189.34 ms      209.83 ms
-Poison          2.99      334.67 ms     ±1.92%      335.02 ms      350.10 ms
+jiffy          10.09       99.10 ms     ±2.37%       99.00 ms      104.58 ms
+Jason           8.25      121.24 ms     ±3.95%      121.61 ms      133.06 ms
+Jaxon           5.62      177.87 ms     ±1.98%      177.41 ms      191.61 ms
+Poison          3.04      328.48 ms     ±4.62%      320.33 ms      361.28 ms
 
 Comparison:
-jiffy           9.90
-Jason           7.90 - 1.25x slower
-Jaxon           5.25 - 1.88x slower
-Poison          2.99 - 3.31x slower
+jiffy          10.09
+Jason           8.25 - 1.22x slower
+Jaxon           5.62 - 1.79x slower
+Poison          3.04 - 3.31x slower
 
 ##### With input Issue 90 #####
 Name             ips        average  deviation         median         99th %
-jiffy          50.56       19.78 ms     ±7.32%       18.93 ms       23.73 ms
-Jaxon          33.66       29.71 ms     ±5.41%       29.11 ms       34.84 ms
-Jason           7.70      129.80 ms     ±2.70%      129.41 ms      138.48 ms
-Poison          5.25      190.39 ms     ±2.45%      191.04 ms      200.13 ms
+jiffy          52.92       18.90 ms     ±3.71%       18.74 ms       22.61 ms
+Jaxon          45.38       22.04 ms     ±2.86%       21.92 ms       25.20 ms
+Jason           7.97      125.43 ms     ±1.88%      125.42 ms      138.12 ms
+Poison          5.55      180.09 ms     ±1.14%      179.87 ms      186.89 ms
 
 Comparison:
-jiffy          50.56
-Jaxon          33.66 - 1.50x slower
-Jason           7.70 - 6.56x slower
-Poison          5.25 - 9.63x slower
+jiffy          52.92
+Jaxon          45.38 - 1.17x slower
+Jason           7.97 - 6.64x slower
+Poison          5.55 - 9.53x slower
 
 ##### With input JSON Generator #####
 Name             ips        average  deviation         median         99th %
-jiffy         375.32        2.66 ms     ±6.12%        2.70 ms        3.22 ms
-Jaxon         286.40        3.49 ms    ±13.64%        3.42 ms        4.97 ms
-Jason         283.68        3.53 ms    ±14.50%        3.41 ms        5.08 ms
-Poison        105.77        9.45 ms    ±10.15%        9.07 ms       12.30 ms
+jiffy         374.65        2.67 ms     ±6.72%        2.72 ms        2.93 ms
+Jason         324.19        3.09 ms     ±7.35%        3.00 ms        3.68 ms
+Jaxon         312.02        3.21 ms     ±5.40%        3.19 ms        3.72 ms
+Poison        129.21        7.74 ms     ±3.23%        7.70 ms        8.75 ms
 
 Comparison:
-jiffy         375.32
-Jaxon         286.40 - 1.31x slower
-Jason         283.68 - 1.32x slower
-Poison        105.77 - 3.55x slower
+jiffy         374.65
+Jason         324.19 - 1.16x slower
+Jaxon         312.02 - 1.20x slower
+Poison        129.21 - 2.90x slower
 
 ##### With input JSON Generator (Pretty) #####
 Name             ips        average  deviation         median         99th %
-jiffy         316.93        3.16 ms    ±10.92%        3.15 ms        4.30 ms
-Jaxon         274.98        3.64 ms    ±13.21%        3.60 ms        4.95 ms
-Jason         229.10        4.37 ms    ±14.63%        4.34 ms        6.55 ms
-Poison         98.62       10.14 ms     ±9.75%        9.79 ms       13.01 ms
+Jaxon         360.06        2.78 ms     ±5.47%        2.74 ms        3.27 ms
+jiffy         330.49        3.03 ms     ±8.56%        3.05 ms        3.72 ms
+Jason         268.88        3.72 ms     ±4.11%        3.69 ms        4.35 ms
+Poison        117.45        8.51 ms     ±4.64%        8.44 ms       10.19 ms
 
 Comparison:
-jiffy         316.93
-Jaxon         274.98 - 1.15x slower
-Jason         229.10 - 1.38x slower
-Poison         98.62 - 3.21x slower
+Jaxon         360.06
+jiffy         330.49 - 1.09x slower
+Jason         268.88 - 1.34x slower
+Poison        117.45 - 3.07x slower
 
 ##### With input Pokedex #####
 Name             ips        average  deviation         median         99th %
-Jason         517.19        1.93 ms    ±14.00%        1.83 ms        3.06 ms
-jiffy         454.35        2.20 ms    ±17.93%        2.37 ms        3.08 ms
-Jaxon         379.63        2.63 ms    ±19.65%        2.53 ms        4.08 ms
-Poison        138.11        7.24 ms    ±11.33%        6.95 ms        9.88 ms
+Jason         549.79        1.82 ms     ±6.76%        1.79 ms        2.22 ms
+jiffy         457.09        2.19 ms    ±16.84%        2.37 ms        2.69 ms
+Jaxon         431.86        2.32 ms     ±8.12%        2.36 ms        2.84 ms
+Poison        176.66        5.66 ms     ±3.88%        5.63 ms        6.42 ms
 
 Comparison:
-Jason         517.19
-jiffy         454.35 - 1.14x slower
-Jaxon         379.63 - 1.36x slower
-Poison        138.11 - 3.74x slower
+Jason         549.79
+jiffy         457.09 - 1.20x slower
+Jaxon         431.86 - 1.27x slower
+Poison        176.66 - 3.11x slower
 
 ##### With input UTF-8 escaped #####
 Name             ips        average  deviation         median         99th %
-jiffy         9.42 K       0.106 ms    ±21.51%      0.0960 ms       0.191 ms
-Jaxon         7.54 K       0.133 ms    ±22.53%       0.122 ms        0.24 ms
-Jason         0.90 K        1.11 ms    ±16.42%        1.07 ms        1.84 ms
-Poison        0.79 K        1.27 ms    ±26.78%        1.17 ms        2.29 ms
+jiffy        10.04 K      0.0996 ms    ±15.52%      0.0960 ms       0.159 ms
+Jaxon         8.89 K       0.113 ms    ±10.89%       0.110 ms       0.168 ms
+Jason         0.98 K        1.02 ms    ±10.04%        1.03 ms        1.27 ms
+Poison        0.96 K        1.05 ms     ±9.16%        1.04 ms        1.29 ms
 
 Comparison:
-jiffy         9.42 K
-Jaxon         7.54 K - 1.25x slower
-Jason         0.90 K - 10.45x slower
-Poison        0.79 K - 11.99x slower
+jiffy        10.04 K
+Jaxon         8.89 K - 1.13x slower
+Jason         0.98 K - 10.26x slower
+Poison        0.96 K - 10.49x slower
 
 ##### With input UTF-8 unescaped #####
 Name             ips        average  deviation         median         99th %
-Jaxon        20.39 K       49.04 μs    ±30.94%          45 μs          95 μs
-jiffy        15.31 K       65.32 μs    ±26.86%          59 μs         126 μs
-Jason         5.44 K      183.90 μs    ±22.94%         165 μs         351 μs
-Poison        3.03 K      329.93 μs    ±19.50%         313 μs         610 μs
+Jaxon        28.92 K       34.59 μs    ±29.30%          33 μs          67 μs
+jiffy        15.83 K       63.19 μs    ±20.86%          60 μs         113 μs
+Jason         5.70 K      175.42 μs    ±17.81%         160 μs         287 μs
+Poison        3.23 K      309.96 μs    ±10.27%         308 μs         418 μs
 
 Comparison:
-Jaxon        20.39 K
-jiffy        15.31 K - 1.33x slower
-Jason         5.44 K - 3.75x slower
-Poison        3.03 K - 6.73x slower
+Jaxon        28.92 K
+jiffy        15.83 K - 1.83x slower
+Jason         5.70 K - 5.07x slower
+Poison        3.23 K - 8.96x slower
 ```

--- a/c_src/decoder_nif.c
+++ b/c_src/decoder_nif.c
@@ -118,7 +118,7 @@ inline double timespec_to_ms(struct timespec *t) {
 
 void get_current_monotic_time(struct timespec* timestamp) {
 /* clock_gettime is only supported from OS X 10.12 (Sierra) */
-#if __MAC_OS_X_VERSION_MIN_REQUIRED < 101200
+#if __MACH__ && __MAC_OS_X_VERSION_MIN_REQUIRED < 101200
   static clock_serv_t clock_server;
   static int clock_server_initialised = 0;
 

--- a/c_src/decoder_nif.c
+++ b/c_src/decoder_nif.c
@@ -116,46 +116,42 @@ inline double timespec_to_ms(struct timespec *t) {
     return ((double)t->tv_sec / 1000.0) + ((double)t->tv_nsec / 1000000.0);
 }
 
-/**
- * get_currect_utc_time:
- *
- * This function hides the difference between getting the UTC time
- * on a MACH based platform or not. MACH doesn't have `clock_gettime`
- * function that's why it must be implemented.
- *
- * Based on https://github.com/balabit/syslog-ng/blob/fb94f1a5e562295341c691b63b9a63bd0b4ebb55/lib/timeutils.c
- **/
-struct timespec
-get_current_utc_time(void)
-{
-  struct timespec timestamp;
-#ifdef __MACH__
-  clock_serv_t clock_server;
+void get_current_monotic_time(struct timespec* timestamp) {
+/* clock_gettime is only supported from OS X 10.12 (Sierra) */
+#if __MAC_OS_X_VERSION_MIN_REQUIRED < 101200
+  static clock_serv_t clock_server;
+  static int clock_server_initialised = 0;
+
   mach_timespec_t mach_timestamp;
-  host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &clock_server);
+
+  if(!clock_server_initialised) {
+      host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &clock_server);
+      clock_server_initialised = 1;
+  }
+
   clock_get_time(clock_server, &mach_timestamp);
-  mach_port_deallocate(mach_task_self(), clock_server);
-  timestamp.tv_sec = mach_timestamp.tv_sec;
-  timestamp.tv_nsec = mach_timestamp.tv_nsec;
+
+  timestamp->tv_sec = mach_timestamp.tv_sec;
+  timestamp->tv_nsec = mach_timestamp.tv_nsec;
 #else
-  clock_gettime(CLOCK_MONOTONIC_RAW, &timestamp);
+  clock_gettime(CLOCK_MONOTONIC_RAW, timestamp);
 #endif
-  return timestamp;
 }
 
 ERL_NIF_TERM decode_binary(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
+    struct timespec start, last, now, tmp;
     decoder_t decoder;
     ErlNifBinary input, input_copy_bin;
     size_t event_terms_count = 0, event_terms_allocated = 8192;
-    ERL_NIF_TERM *event_terms = malloc(sizeof(ERL_NIF_TERM) * event_terms_allocated);
+    ERL_NIF_TERM stack_terms[event_terms_allocated];
+    ERL_NIF_TERM *event_terms = &stack_terms[0];
     json_event_t event ;
     ERL_NIF_TERM binary, ret, input_copy;
     uint8_t* value;
-    struct timespec start, last, now, tmp;
     int total_slice = 0;
 
-    start = get_current_utc_time();
-    last = get_current_utc_time();
+    get_current_monotic_time(&start);
+    get_current_monotic_time(&last);
 
     private_data_t *data = (private_data_t*)enif_priv_data(env);
 
@@ -175,42 +171,40 @@ ERL_NIF_TERM decode_binary(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) 
 
     while(event.type < SYNTAX_ERROR) {
         if(decoder.cursor < buffer + input.size && event.type > UNDEFINED) {
-            now = get_current_utc_time();
+            get_current_monotic_time(&now);
 
-            double since_last = timespec_to_ms(&now) - timespec_to_ms(&last);
-            int slice = floor(since_last * 100.0);
+            double since_start = timespec_to_ms(&now) - timespec_to_ms(&start);
 
-            if (slice > 0) {
-                if(slice < 0) slice = 0;
-                else if(slice > 100) slice = 100;
-
-                /* total_slice += slice; */
-                /* double since_start = timespec_to_ms(&now) - timespec_to_ms(&start); */
-
-                if(enif_consume_timeslice(env, slice)) {
-                    binary =
-                        enif_make_sub_binary(
+            if(since_start > 1.0) {
+                binary =
+                    enif_make_sub_binary(
                             env,
                             input_copy,
                             (decoder.cursor - buffer),
                             (buffer + input.size) - decoder.cursor
-                        );
+                            );
 
-                    return enif_make_tuple3(
-                            env,
-                            data->nif_yield,
-                            enif_make_list_from_array(env, event_terms, event_terms_count),
-                            binary
+                return enif_make_tuple3(
+                        env,
+                        data->nif_yield,
+                        enif_make_list_from_array(env, event_terms, event_terms_count),
+                        binary
                         );
-                }
-                last = now;
             }
         }
 
         if(event_terms_count == event_terms_allocated) {
             event_terms_allocated *= 2;
-            event_terms =
-                realloc(event_terms, sizeof(ERL_NIF_TERM) * event_terms_allocated);
+
+            if(event_terms == &stack_terms[0]) {
+                event_terms =
+                    malloc(sizeof(ERL_NIF_TERM) * event_terms_allocated);
+
+                memcpy(event_terms, &stack_terms[0], sizeof(stack_terms));
+            } else {
+                event_terms =
+                    realloc(event_terms, sizeof(ERL_NIF_TERM) * event_terms_allocated);
+            }
         }
 
         decode(&decoder, &event);

--- a/lib/jaxon.ex
+++ b/lib/jaxon.ex
@@ -43,6 +43,11 @@ defmodule Jaxon do
   ```
   """
   @spec decode(String.t()) :: {:ok, Jaxon.Decoder.json_term()} | {:error, %Jaxon.ParseError{}}
+  def decode(binary) when byte_size(binary) <= @decode_chunk_size do
+    (Jaxon.Parser.parse(binary) ++ [:end_stream])
+    |> Jaxon.Decoder.events_to_term()
+  end
+
   def decode(binary) do
     do_decode(binary, 0, @decode_chunk_size, &Jaxon.Decoder.events_to_term/1)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Jaxon.MixProject do
     [
       app: :jaxon,
       name: "Jaxon",
-      version: "1.0.2",
+      version: "1.0.3",
       elixir: "~> 1.6",
       compilers: [:elixir_make] ++ Mix.compilers(),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
* Avoid chunking a binary for parsing if it's size is less than a chunk
* Use `clock_gettime` when available in OS X
* Always return the NIF call after a 1ms has elapsed
* Avoid an initial `malloc` call for the event array