### PR TITLE
Fix boolean parsing

### DIFF
--- a/c_src/decoder.c
+++ b/c_src/decoder.c
@@ -448,7 +448,7 @@ void decode(decoder_t* d, json_event_t* e) {
             if(d->cursor + 5 <= limit) {
                 if(memcmp(d->cursor, "false", 5) == 0) {
                     e->type = BOOLEAN;
-                    e->value.boolean = 1;
+                    e->value.boolean = 0;
                     d->cursor = d->cursor + 5;
                 } else {
                     syntax_error(d, e);

--- a/test/jaxon_test.exs
+++ b/test/jaxon_test.exs
@@ -55,6 +55,11 @@ defmodule JaxonTest do
     assert decode!("-99.99e99 ") == -99.99e99
   end
 
+  test "booleans" do
+    assert decode!(~s(true)) == true
+    assert decode!(~s(false)) == false
+  end
+
   test "objects" do
     assert decode!(~s({})) == %{}
     assert decode!(~s({"number": 2})) == %{"number" => 2}

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -4,7 +4,7 @@ defmodule ParseTest do
   doctest Parser
 
   @tests [
-    {~s({ "name": "john", "test": {"number": 5.1}, "tags":[null,true,true,1]}),
+    {~s({ "name": "john", "test": {"number": 5.1}, "tags":[null,true,false,1]}),
      [
        :start_object,
        {:string, "name"},
@@ -26,7 +26,7 @@ defmodule ParseTest do
        :comma,
        {:boolean, true},
        :comma,
-       {:boolean, true},
+       {:boolean, false},
        :comma,
        {:integer, 1},
        :end_array,


### PR DESCRIPTION
Hey there!
While playing around with the library I stumbled over the bug, that all my `false` boolean values were parsed as `true`. So I added tests to recreate the problem and fixed it.

Cheers!