### PR TITLE
Handle empty strings as keys properly

### DIFF
--- a/lib/jaxon/path.ex
+++ b/lib/jaxon/path.ex
@@ -210,6 +210,10 @@ defmodule Jaxon.Path do
     "[#{i}]"
   end
 
+  defp do_encode_segment("") do
+    ~s("")
+  end
+
   defp do_encode_segment(s) when is_binary(s) do
     if(String.contains?(s, ["*", "$", "]", "[", ".", "\""])) do
       "\"#{String.replace(s, "\"", "\\\"")}\""

--- a/test/jaxon_test.exs
+++ b/test/jaxon_test.exs
@@ -63,6 +63,7 @@ defmodule JaxonTest do
   test "objects" do
     assert decode!(~s({})) == %{}
     assert decode!(~s({"number": 2})) == %{"number" => 2}
+    assert decode!(~s({"": 2})) == %{"" => 2}
     assert decode!(~s({"nested": {}})) == %{"nested" => %{}}
     assert decode!(~s({"nested": {"nested": 2}})) == %{"nested" => %{"nested" => 2}}
   end

--- a/test/path_test.exs
+++ b/test/path_test.exs
@@ -11,7 +11,7 @@ defmodule JaxonPathTest do
     assert encode!([:root, :all]) == "$[*]"
     assert encode!([:root, :all, :all]) == "$[*][*]"
     assert encode!([:root, "$", :all]) == "$.\"$\"[*]"
-    assert encode!([:root, "", :all]) == "$[*]"
+    assert encode!([:root, "", :all]) == ~s($.""[*])
 
     assert_raise(EncodeError, "`:whoops` is not a valid JSON path segment", fn ->
       encode!([:root, :whoops, "test", 0])
@@ -26,6 +26,7 @@ defmodule JaxonPathTest do
     assert parse!("$.\"nested\"[0]") == [:root, "nested", 0]
     assert parse!("$.\"nested\".0") == [:root, "nested", "0"]
     assert parse!("$.\"$\".0") == [:root, "$", "0"]
+    assert parse!(~s($.""[0])) == [:root, "", 0]
 
     assert_raise(ParseError, ~r/Ending quote not found.*/, fn ->
       parse!("$.\"nested.0")

--- a/test/stream_test.exs
+++ b/test/stream_test.exs
@@ -24,6 +24,7 @@ defmodule JaxonEventStreamTest do
       "empty_array": [],
       "empty_object": {},
       "bool1": true,
+      "": "empty",
       "bool2": false,
       "null": null,
       "person": {
@@ -49,6 +50,7 @@ defmodule JaxonEventStreamTest do
       stream = Util.chunk_binary(@json_stream, chunk_size)
 
       assert [1] == query(stream, "$.numbers[0]")
+      assert ["empty"] == query(stream, ~s($.""))
       assert [nil] == query(stream, "$.null")
       assert [2] == query(stream, "$.numbers[1]")
       assert [[1, 2, -1]] == query(stream, "$.numbers")


### PR DESCRIPTION
This:
`[:root, "", :all]` => `$[*]`

Should be:
`[:root, "", :all]` => `$.""[*]`

As empty string is also a valid JSON key.