### PR TITLE
fix: fix typespecs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
   - mix compile --warnings-as-errors
   - mix format --check-formatted --dry-run
   - mix coveralls.travis
-  # - mix dialyzer --halt-exit-status
+  - mix dialyzer --halt-exit-status
 after_script:
   - mix inch.report
 before_cache:

--- a/lib/jaxon/parse_error.ex
+++ b/lib/jaxon/parse_error.ex
@@ -1,5 +1,9 @@
 defmodule Jaxon.ParseError do
-  @type t :: %__MODULE__{message: String.t(), unexpected: atom(), expected: [atom()]}
+  @type t :: %__MODULE__{
+          message: String.t() | nil,
+          unexpected: {:incomplete, String.t()} | {:error, String.t()} | nil,
+          expected: [atom()] | nil
+        }
 
   defexception [:message, :unexpected, :expected]
 

--- a/lib/jaxon/parser.ex
+++ b/lib/jaxon/parser.ex
@@ -2,9 +2,9 @@ defmodule Jaxon.Parser do
   @parser Application.get_env(:jaxon, :parser, Jaxon.Parsers.NifParser)
 
   @type parse_return() ::
-          {:ok, [Jaxon.Event.t()]}
+          {:ok, list(Jaxon.Event.t())}
+          | {:incomplete, list(Jaxon.Event.t()), String.t()}
           | {:error, Jaxon.ParseError.t()}
-          | {:incomplete, [Jaxon.Event.t()], String.t()}
 
   @callback parse(String.t(), Keyword.t()) :: parse_return()
 
@@ -46,6 +46,7 @@ defmodule Jaxon.Parser do
   ```
   """
 
+  @spec parse(String.t()) :: parse_return()
   @spec parse(String.t(), Keyword.t()) :: parse_return()
   defdelegate parse(events, opts \\ []), to: @parser
 end

--- a/lib/jaxon/parsers/nif_parser.ex
+++ b/lib/jaxon/parsers/nif_parser.ex
@@ -1,7 +1,13 @@
 defmodule Jaxon.Parsers.NifParser do
   @moduledoc false
+
   @on_load :load_nifs
   @behaviour Jaxon.Parser
+
+  @type parse_return() ::
+          {:ok, list(Jaxon.Event.t())}
+          | {:incomplete, list(Jaxon.Event.t()), String.t()}
+          | {:error, Jaxon.ParseError.t()}
 
   def load_nifs do
     nif_filename =
@@ -48,6 +54,7 @@ defmodule Jaxon.Parsers.NifParser do
     end
   end
 
+  @spec parse(String.t(), Keyword.t()) :: parse_return()
   def parse(binary, opts) do
     allow_incomplete = Keyword.get(opts, :allow_incomplete, true)
 

--- a/lib/jaxon/path.ex
+++ b/lib/jaxon/path.ex
@@ -27,7 +27,7 @@ defmodule Jaxon.Path do
   {:error, %Jaxon.EncodeError{message: "`:whoops` is not a valid JSON path segment"}}
   ```
   """
-  @spec encode(t()) :: {:ok, String.t()} | {:error, String.t()}
+  @spec encode(t()) :: {:ok, String.t()} | {:error, EncodeError.t()}
   def encode(path) do
     case do_encode(path) do
       {:error, err} ->
@@ -56,7 +56,7 @@ defmodule Jaxon.Path do
   {:error, %Jaxon.ParseError{message: "Ending quote not found for string at `\"test[x]`"}}
   ```
   """
-  @spec parse(String.t()) :: {:ok, t} | {:error, String.t()}
+  @spec parse(String.t()) :: {:ok, t()} | {:error, ParseError.t()}
   def parse(bin) do
     case parse_json_path(bin, "", []) do
       {:error, err} ->

--- a/lib/jaxon/path.ex
+++ b/lib/jaxon/path.ex
@@ -5,7 +5,7 @@ defmodule Jaxon.Path do
   Utility module for parsing and encoding JSON path expressions.
   """
 
-  @type t :: [String.t() | :all | :root | integer]
+  @type t :: list(String.t() | :all | :root | integer)
 
   @doc ~S"""
   Encoding path expressions:

--- a/lib/jaxon/stream.ex
+++ b/lib/jaxon/stream.ex
@@ -40,7 +40,7 @@ defmodule Jaxon.Stream do
   [[:start_object, {:string, "jaxon"}]]
   ```
   """
-  @spec from_enumerable(String.t()) :: event_stream()
+  @spec from_enumerable(Enumerable.t()) :: event_stream()
   def from_enumerable(bin_stream) do
     Stream.transform(bin_stream, "", fn chunk, tail ->
       chunk = tail <> chunk

--- a/lib/jaxon/stream.ex
+++ b/lib/jaxon/stream.ex
@@ -26,7 +26,7 @@ defmodule Jaxon.Stream do
   ```
   """
 
-  @spec query(event_stream(), [Path.t()]) :: term_stream()
+  @spec query(event_stream(), Path.t()) :: term_stream()
   defdelegate query(event_stream, query), to: Decoders.Query
 
   @spec values(event_stream()) :: term_stream()

--- a/lib/jaxon/stream.ex
+++ b/lib/jaxon/stream.ex
@@ -45,9 +45,9 @@ defmodule Jaxon.Stream do
     Stream.transform(bin_stream, "", fn chunk, tail ->
       chunk = tail <> chunk
 
-      events = Parser.parse(chunk)
-
-      case events do
+      chunk
+      |> Parser.parse()
+      |> case do
         {:incomplete, events, tail} ->
           {[events], tail}
 


### PR DESCRIPTION
Found some problems with typings when I added this  dependency to a project running with dialyzer and fixed the typos on this PR.

Also, I found something that seemed to be wrong with the path parser: since it appends results to a list and wasn't checking for errors on this recursion, it was possible to have an error appended to the result list, as below:

```elixir
# correct example
iex(1)> Jaxon.Path.parse("$[*].pets[0]")
{:ok, [:root, :all, "pets", 0]}

# wrong example
iex(2)> Jaxon.Path.parse("$[*].pets[0") 
{:ok, [:root, :all | {:error, "Ending bracket not found for string at `[0`"}]}
```

With this fix, checking for errors before appending to the result list, if you have an error, it will be returned:
```elixir
# correct example
iex(1)> Jaxon.Path.parse("$[*].pets[0]")
{:ok, [:root, :all, "pets", 0]}

# wrong example
iex(2)> Jaxon.Path.parse("$[*].pets[0") 
{:error,
 %Jaxon.ParseError{
   expected: nil,
   message: "Ending bracket not found for string at `[0`",
   unexpected: nil
 }}
```