### PR TITLE
fix: SyntaxError when parsing chunked decimal with exponential

### DIFF
--- a/c_src/decoder.c
+++ b/c_src/decoder.c
@@ -120,7 +120,7 @@ void parse_number(decoder_t* d, json_event_t* e) {
             buf += 1;
         }
 
-        if(!is_digit(*buf)) {
+        if(buf < limit && !is_digit(*buf)) {
             syntax_error(d, e);
             return;
         }

--- a/test/stream_test.exs
+++ b/test/stream_test.exs
@@ -183,4 +183,39 @@ defmodule JaxonEventStreamTest do
       |> Enum.to_list()
     end)
   end
+
+  test "correctly parses chunked decimal with exponential" do
+    expected = [
+      %{
+        "decimal" => 1.234e+7
+      },
+      %{
+        "decimal" => 1.234e-7
+      },
+      %{
+        "decimal" => 1.234e+7
+      },
+      %{
+        "decimal" => 1.234e-7
+      }
+    ]
+
+    result =
+      [
+        ~s([{"decimal": 1.234e+7),
+        ~s(},),
+        ~s({"decimal": 1.234e-),
+        ~s(7},),
+        ~s({"decimal": 1.234e),
+        ~s(+7},),
+        ~s({"decimal": 1.234),
+        ~s(e-7}])
+      ]
+      |> Jaxon.Stream.from_enumerable()
+      |> Jaxon.Stream.query([:root])
+      |> Enum.to_list()
+      |> List.first()
+
+    assert result == expected
+  end
 end


### PR DESCRIPTION
### Issue
When a decimal with exponential (e.g. `0.1234e-5`) is chunked right after the exponential sign, `Jaxon.Stream` raises a `ParseError` complaining about a syntax error, although the JSON is valid.

Example:
```
iex(1)> [~s({"decimal":1.123e-), ~s(4})] |> Jaxon.Stream.from_enumerable() |> Stream.run()
** (Jaxon.ParseError) Syntax error at `{"decimal":1.123e-`
    (jaxon 2.0.0) lib/jaxon/stream.ex:55: anonymous fn/2 in Jaxon.Stream.from_enumerable/1
    (elixir 1.12.0) lib/stream.ex:902: Stream.do_transform_user/6
    (elixir 1.12.0) lib/stream.ex:649: Stream.run/1
```

### Solution
The C decoder, after reading the exponential sign, moves move to the next character and checks if it's a digit _without checking if we reached the end of the buffer_.
When the buffer ends with the exponential sign, it will check if the next address in memory is a digit to decide wether the decimal is legit.

Checking if we reached the end of the buffer prevents this behaviour.