### PR TITLE
fix syntax error in concatenation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Query a large file without holding the whole file in memory:
 |> File.stream!()
 |> Jaxon.Stream.from_enumerable()
 |> Jaxon.Stream.query([:root, "users", :all, "metadata"])
-|> Stream.map(&(&1["username"],",",&1["email"],"\n"))
+|> Stream.map(&[&1["username"],",",&1["email"],"\n"])
 |> Stream.into(File.stream!("large_file.csv"))
 |> Stream.run()
 ```


### PR DESCRIPTION
parenthesis were throwing syntax error. 
square brackets are required for concatenating elements.